### PR TITLE
fix: Fixed smb block by making it dynamic

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -78,14 +78,21 @@ resource "azurerm_storage_account" "sa" {
       days = try(var.storage.share_properties.retention_in_days, 7)
     }
 
-    smb {
-      versions                        = try(var.storage.share_properties.smb.versions, [])
-      authentication_types            = try(var.storage.share_properties.smb.authentication_types, [])
-      channel_encryption_type         = try(var.storage.share_properties.smb.channel_encryption_type, [])
-      multichannel_enabled            = try(var.storage.share_properties.smb.multichannel_enabled, null)
-      kerberos_ticket_encryption_type = try(var.storage.share_properties.smb.kerb_ticket_encryption_type, [])
+    dynamic "smb" {
+      for_each = {
+        for k, v in try(var.storage.share_properties.smb, {}) : k => v
+      }
+
+      content {
+        versions                        = try(var.storage.share_properties.smb.versions, [])
+        authentication_types            = try(var.storage.share_properties.smb.authentication_types, [])
+        channel_encryption_type         = try(var.storage.share_properties.smb.channel_encryption_type, [])
+        multichannel_enabled            = try(var.storage.share_properties.smb.multichannel_enabled, null)
+        kerberos_ticket_encryption_type = try(var.storage.share_properties.smb.kerb_ticket_encryption_type, [])
+      }
     }
   }
+
 
   queue_properties {
     dynamic "cors_rule" {

--- a/main.tf
+++ b/main.tf
@@ -87,7 +87,7 @@ resource "azurerm_storage_account" "sa" {
         versions                        = try(var.storage.share_properties.smb.versions, [])
         authentication_types            = try(var.storage.share_properties.smb.authentication_types, [])
         channel_encryption_type         = try(var.storage.share_properties.smb.channel_encryption_type, [])
-        multichannel_enabled            = try(var.storage.share_properties.smb.multichannel_enabled, null)
+        multichannel_enabled            = try(var.storage.share_properties.smb.multichannel_enabled, false)
         kerberos_ticket_encryption_type = try(var.storage.share_properties.smb.kerb_ticket_encryption_type, [])
       }
     }

--- a/main.tf
+++ b/main.tf
@@ -82,7 +82,7 @@ resource "azurerm_storage_account" "sa" {
       versions                        = try(var.storage.share_properties.smb.versions, [])
       authentication_types            = try(var.storage.share_properties.smb.authentication_types, [])
       channel_encryption_type         = try(var.storage.share_properties.smb.channel_encryption_type, [])
-      multichannel_enabled            = try(var.storage.share_properties.smb.multichannel_enabled, [])
+      multichannel_enabled            = try(var.storage.share_properties.smb.multichannel_enabled, null)
       kerberos_ticket_encryption_type = try(var.storage.share_properties.smb.kerb_ticket_encryption_type, [])
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -82,7 +82,7 @@ resource "azurerm_storage_account" "sa" {
       versions                        = try(var.storage.share_properties.smb.versions, [])
       authentication_types            = try(var.storage.share_properties.smb.authentication_types, [])
       channel_encryption_type         = try(var.storage.share_properties.smb.channel_encryption_type, [])
-      multichannel_enabled            = try(var.storage.share_properties.smb.multichannel_enabled, false)
+      multichannel_enabled            = try(var.storage.share_properties.smb.multichannel_enabled, [])
       kerberos_ticket_encryption_type = try(var.storage.share_properties.smb.kerb_ticket_encryption_type, [])
     }
   }


### PR DESCRIPTION
- See also issue, when not doing anything at all with the smb block (under the share_propterties block) it would always try to set the multichannel enabled to false or true (if set). Even after a apply, it would detect it again as a change. 

