### PR TITLE
fix: smb block only to 1 instance instead of multiple

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -79,9 +79,7 @@ resource "azurerm_storage_account" "sa" {
     }
 
     dynamic "smb" {
-      for_each = {
-        for k, v in try(var.storage.share_properties.smb, {}) : k => v
-      }
+      for_each = try(var.storage.share_properties.smb, null) != null ? [1] : []
 
       content {
         versions                        = try(var.storage.share_properties.smb.versions, [])


### PR DESCRIPTION
 set the for each within the dynamic block to [1] (enabled) or [] (disabled) instead of multiple smb blocks which are not allowed